### PR TITLE
[jobczar] extract http addr in config

### DIFF
--- a/infra/jobczar/config.go
+++ b/infra/jobczar/config.go
@@ -10,8 +10,10 @@ import (
 // LATER move parts of this to a separate package
 
 type Config struct {
-	DB_CONNECT  string
-	SERVER_ADDR string
+	DB_CONNECT         string
+	THRIFT_SERVER_ADDR string
+	HTTP_SERVER_ADDR   string
+	IS_LOCALHOST       bool
 }
 
 func (config *Config) Load() {
@@ -27,7 +29,9 @@ func (config *Config) Load() {
 
 func (config *Config) setDefaults() {
 	config.DB_CONNECT = ""
-	config.SERVER_ADDR = "localhost:9009"
+	config.THRIFT_SERVER_ADDR = "localhost:9009"
+	config.HTTP_SERVER_ADDR = "localhost:8000"
+	config.IS_LOCALHOST = false
 }
 
 func (config *Config) ensureRequired() {

--- a/infra/jobczar/jobczar.example.cfg
+++ b/infra/jobczar/jobczar.example.cfg
@@ -4,3 +4,6 @@
 # here jobs is a user identified by password on the obelisk database
 # so replace that with your own credentials
 DB_CONNECT="jobs:password@tcp(127.0.0.1)/obelisk"
+
+# this is mostly used to bypass the CORS error that the browser throws when testing locally
+IS_LOCALHOST=true

--- a/infra/jobczar/jobczar.go
+++ b/infra/jobczar/jobczar.go
@@ -52,7 +52,7 @@ func main() {
 	if gConfig.IS_LOCALHOST {
 		// this is just a hack for localhost testing
 		c := cors.New(cors.Options{
-			AllowedOrigins: []string{"http://test.com", "127.0.0.1", "localhost", "localhost:8000", "localhost:9009", "null"},
+			AllowedOrigins: []string{"*"},
 		})
 		goji.Use(c.Handler)
 	}

--- a/infra/jobczar/jobczar.go
+++ b/infra/jobczar/jobczar.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 
@@ -48,19 +49,22 @@ func main() {
 
 	gDatabase.Connect()
 
-	log.Info("listening on ", gConfig.SERVER_ADDR)
-
-	// this is just a hack for localhost testing
-	c := cors.New(cors.Options{
-		AllowedOrigins: []string{"http://test.com", "127.0.0.1", "localhost", "localhost:8000", "localhost:9009", "null"},
-	})
-	goji.Use(c.Handler)
+	if gConfig.IS_LOCALHOST {
+		// this is just a hack for localhost testing
+		c := cors.New(cors.Options{
+			AllowedOrigins: []string{"http://test.com", "127.0.0.1", "localhost", "localhost:8000", "localhost:9009", "null"},
+		})
+		goji.Use(c.Handler)
+	}
 
 	handler := RequestHandler{}
 	server := MakeServer(handler)
 
 	go httpServer(&handler)
 	go server.Serve()
+
+	log.Info("thrift server listening on ", gConfig.THRIFT_SERVER_ADDR)
+	log.Info("http server listening on ", gConfig.HTTP_SERVER_ADDR)
 
 	for true {
 		var command string
@@ -97,12 +101,16 @@ func httpServer(handler *RequestHandler) {
 
 	goji.Post("/jobczar", NewThriftHandlerFunc(processor, factory, factory))
 
-	goji.Serve()
+	listener, err := net.Listen("tcp", gConfig.HTTP_SERVER_ADDR)
+	if err != nil {
+		log.Fatal(err)
+	}
+	goji.ServeListener(listener)
 }
 
 func MakeServer(handler infra.JobCzar) *thrift.TSimpleServer {
 	transportFactory := thrift.NewTBufferedTransportFactory(8192)
-	transport, _ := thrift.NewTServerSocket(gConfig.SERVER_ADDR)
+	transport, _ := thrift.NewTServerSocket(gConfig.THRIFT_SERVER_ADDR)
 	processor := infra.NewJobCzarProcessor(handler)
 	protocolFactory := thrift.NewTBinaryProtocolFactoryConf(nil)
 	server := thrift.NewTSimpleServer4(processor, transport, transportFactory, protocolFactory)


### PR DESCRIPTION
To avoid confusion between thrift and http addresses we explicitly set both in the config now.
