### PR TITLE
[jobboard] run a simple server so we can use js modules

### DIFF
--- a/infra/jobboard/board.js
+++ b/infra/jobboard/board.js
@@ -1,4 +1,7 @@
 
+import { SERVER_URL } from "./config.js";
+console.log("server url is", SERVER_URL)
+
 const gServerURL = "http://localhost:8000/jobczar"; // /JobCzar
 
 // thrift client that talks to the server

--- a/infra/jobboard/config.js
+++ b/infra/jobboard/config.js
@@ -1,0 +1,2 @@
+// jobczar address
+export const SERVER_URL = "http://localhost:8000/";

--- a/infra/jobboard/jobboard.html
+++ b/infra/jobboard/jobboard.html
@@ -9,10 +9,12 @@
     <body>
         <script src="jquery.min.js"></script>
         <script src="bootstrap.min.js"></script>
+
         <script src="thrift.js"></script>
         <script src="../genjs/infra_types.js"></script>
         <script src="../genjs/JobCzar.js"></script>
-        <script src="board.js"></script>
+
+        <script type="module" src="board.js"></script>
 
         <div class="container">Match idle workers with rewarding work.</div>
 

--- a/infra/jobboard/simple_server.sh
+++ b/infra/jobboard/simple_server.sh
@@ -1,0 +1,1 @@
+python -m http.server 8080


### PR DESCRIPTION
Without a server the browser does not allow us to load javascript files as modules.

This PR doesn't fully work because the genjs dir is one level up and we can't seem to import it.
This probably requires a build script or something to bring it in but that seems too involved for what we want.

Shelving this until we find something simpler.
